### PR TITLE
fix(core): implement dynamic asset typing and remove hardcoded ETF list

### DIFF
--- a/src/dataService.js
+++ b/src/dataService.js
@@ -266,7 +266,7 @@ export class DataService {
 
       const data = {
         symbol,
-        type: 'stock',
+        type: meta.instrumentType,
         price: currentPrice,
         change,
         change24h: change,

--- a/src/index.js
+++ b/src/index.js
@@ -190,9 +190,8 @@ class StonksDashboard {
 
   getAssetCategory(asset) {
     if (asset.type === 'crypto') return 'crypto';
-    if (['SPY', 'QQQ', 'VOO', 'VTI', 'IWM', 'DIA', 'ARKK', 'XLF', 'XLE', 'GLD', 'SLV'].includes(asset.symbol)) {
-      return 'etf';
-    }
+    if (asset.type === 'ETF' || asset.type === 'etf') return 'etf';
+    if (asset.type === 'EQUITY' || asset.type === 'equity') return 'stock'
     return 'stock';
   }
 


### PR DESCRIPTION
Hi there! 👋 First of all, congrats on the launch! I really liked the project and while exploring the code, I noticed the ETF logic relied on a hardcoded list. Since there isn't a contributing guide yet, I took the liberty to refactor it to be dynamic based on the API data. Hope this helps!

## What's Changed
This PR refactors how asset types are handled to make the dashboard more scalable and accurate.

1.  Dynamic Data Source (Root Cause): I noticed `src/dataService.js` was defaulting `type: 'stock'` for every asset, which likely necessitated the manual ETF list. I updated this to fetch the actual `instrumentType` from the metadata (`meta.instrumentType`).
2.  Scalable Logic: In `src/index.js`, I removed the hardcoded whitelist of ETF symbols (SPY, QQQ, etc.). The category logic now relies strictly on the dynamic `asset.type` property coming from the API.

## Why?
Previously, adding a new ETF required modifying the source code array. With this change, any ETF (from any market) correctly identified by the API will automatically be categorized as an ETF in the UI without manual intervention.